### PR TITLE
Session preset for unsupporting 4K devices fixed

### DIFF
--- a/QRCodeReader.podspec
+++ b/QRCodeReader.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'QRCodeReader'
-  s.version          = '1.0.5'
+  s.version          = '1.0.6'
   s.summary          = 'iOS framework contain core view elements and logic component for work with QR codes.'
   s.homepage         = 'https://github.com/TouchInstinct/QRCodeReader-ios'
 

--- a/QRCodeReader/Classes/Core/QRCodeReader.swift
+++ b/QRCodeReader/Classes/Core/QRCodeReader.swift
@@ -143,7 +143,11 @@ open class QRCodeReader: NSObject, AVCaptureMetadataOutputObjectsDelegate {
     // MARK: - Private Methods
     
     private func configureDefaultComponents() {
-        session.sessionPreset = .hd4K3840x2160
+        if session.canSetSessionPreset(.hd4K3840x2160) {
+            session.sessionPreset = .hd4K3840x2160
+        } else {
+            session.sessionPreset = .photo
+        }
 
         for output in session.outputs {
             session.removeOutput(output)


### PR DESCRIPTION
Камера iPhone 5S не поддерживает разрешение `4К 3840x2160` (максимум `3264x2448`)

Из-за этого происходит краш в приложении:

[MB-5777](https://jira.lan.ubrr.ru/browse/MB-5777) - Краш мп по тапу на оплата по qr коду

![Снимок экрана 2021-12-15 в 17 19 43](https://user-images.githubusercontent.com/37587023/146185558-8ccab1a3-ba05-407a-ab8d-ef75a5c4e751.png)

---

- Проверяю поддержку `4К3840x2160`, при `false` проставляем `.photo`