### PR TITLE
Session preset support check fixed

### DIFF
--- a/QRCodeReader.podspec
+++ b/QRCodeReader.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'QRCodeReader'
-  s.version          = '1.0.6'
+  s.version          = '1.0.7'
   s.summary          = 'iOS framework contain core view elements and logic component for work with QR codes.'
   s.homepage         = 'https://github.com/TouchInstinct/QRCodeReader-ios'
 

--- a/QRCodeReader/Classes/Core/QRCodeReader.swift
+++ b/QRCodeReader/Classes/Core/QRCodeReader.swift
@@ -143,7 +143,7 @@ open class QRCodeReader: NSObject, AVCaptureMetadataOutputObjectsDelegate {
     // MARK: - Private Methods
     
     private func configureDefaultComponents() {
-        if session.canSetSessionPreset(.hd4K3840x2160) {
+        if defaultDevice?.supportsSessionPreset(.hd4K3840x2160) {
             session.sessionPreset = .hd4K3840x2160
         } else {
             session.sessionPreset = .photo

--- a/QRCodeReader/Classes/Core/QRCodeReader.swift
+++ b/QRCodeReader/Classes/Core/QRCodeReader.swift
@@ -143,10 +143,9 @@ open class QRCodeReader: NSObject, AVCaptureMetadataOutputObjectsDelegate {
     // MARK: - Private Methods
     
     private func configureDefaultComponents() {
-        if defaultDevice?.supportsSessionPreset(.hd4K3840x2160) {
+        if let defaultDevice = defaultDevice,
+           defaultDevice.supportsSessionPreset(.hd4K3840x2160) {
             session.sessionPreset = .hd4K3840x2160
-        } else {
-            session.sessionPreset = .photo
         }
 
         for output in session.outputs {


### PR DESCRIPTION
Использован [`supportsSessionPreset(_:)`](https://developer.apple.com/documentation/avfoundation/avcapturedevice/1386263-supportssessionpreset) вместо [`canSetSessionPreset(_:)`](https://developer.apple.com/documentation/avfoundation/avcapturesession/1389824-cansetsessionpreset/)